### PR TITLE
Add httpContentType to inputStreamReadable

### DIFF
--- a/geny/src/geny/Writable.scala
+++ b/geny/src/geny/Writable.scala
@@ -134,5 +134,6 @@ object Readable{
 
   implicit class InputStreamReadable(i: InputStream) extends Readable{
     def readBytesThrough[T](f: InputStream => T): T = f(i)
+    override def httpContentType = Some("application/octet-stream")
   }
 }

--- a/geny/src/geny/Writable.scala
+++ b/geny/src/geny/Writable.scala
@@ -134,6 +134,6 @@ object Readable{
 
   implicit class InputStreamReadable(i: InputStream) extends Readable{
     def readBytesThrough[T](f: InputStream => T): T = f(i)
-    override def httpContentType = Some("application/octet-stream")
+    override def httpContentType: Option[String] = Some("application/octet-stream")
   }
 }


### PR DESCRIPTION
Since InputStreams manage binary data, we can default it to `application/octet-stream` the same as `Array[Byte]`s or `ByteBuffer`s

Review by @jodersky @lolgab 